### PR TITLE
Minimal updates for the rocq-prover GitHub organization migration.

### DIFF
--- a/coqbot-config.toml
+++ b/coqbot-config.toml
@@ -19,13 +19,13 @@ app_id="31373"
   bot_name="x-CBot"
 
 [mappings]
-  [mappings.coq]
-  github="coq/coq"
-  gitlab="coq/coq"
+  [mappings.rocq]
+  github="rocq-prover/rocq"
+  gitlab="coq/rocq"
   gitlab_domain="gitlab.inria.fr"
 
   [mappings.opam]
-  github="coq/opam"
+  github="rocq-prover/opam"
   gitlab="coq/opam"
   gitlab_domain="gitlab.inria.fr"
 

--- a/src/actions.mli
+++ b/src/actions.mli
@@ -80,7 +80,7 @@ val project_action :
   -> unit
   -> unit Lwt.t
 
-val coq_push_action :
+val rocq_push_action :
      bot_info:Bot_info.t
   -> base_ref:string
   -> commits_msg:string list
@@ -113,7 +113,7 @@ val coq_bug_minimizer_resume_ci_minimization_action :
   -> string
   -> (Cohttp.Response.t * Cohttp_lwt__Body.t) Lwt.t
 
-val coq_check_needs_rebase_pr :
+val rocq_check_needs_rebase_pr :
      bot_info:Bot_info.t
   -> owner:string
   -> repo:string
@@ -122,7 +122,7 @@ val coq_check_needs_rebase_pr :
   -> throttle:int
   -> unit Lwt.t
 
-val coq_check_stale_pr :
+val rocq_check_stale_pr :
      bot_info:Bot_info.t
   -> owner:string
   -> repo:string

--- a/src/bot.ml
+++ b/src/bot.ml
@@ -252,21 +252,21 @@ let callback _conn req body =
       | Ok
           ( Some install_id
           , PushEvent
-              {owner= "coq"; repo= "coq"; base_ref; head_sha; commits_msg} ) ->
+              {owner= "rocq-prover"; repo= "rocq"; base_ref; head_sha; commits_msg} ) ->
           (fun () ->
             init_git_bare_repository ~bot_info
             >>= fun () ->
             action_as_github_app_from_install_id ~bot_info ~key ~app_id
               ~install_id
-              (coq_push_action ~base_ref ~commits_msg)
+              (rocq_push_action ~base_ref ~commits_msg)
             <&> action_as_github_app_from_install_id ~bot_info ~key ~app_id
                   ~install_id
-                  (mirror_action ~gitlab_domain:"gitlab.inria.fr" ~owner:"coq"
-                     ~repo:"coq" ~base_ref ~head_sha () ) )
+                  (mirror_action ~gitlab_domain:"gitlab.inria.fr" ~owner:"rocq-prover"
+                     ~repo:"rocq" ~base_ref ~head_sha () ) )
           |> Lwt.async ;
           Server.respond_string ~status:`OK
             ~body:
-              "Processing push event on Coq repository: analyzing merge / \
+              "Processing push event on the Rocq Prover repository: analyzing merge / \
                backporting info."
             ()
       | Ok (Some install_id, PushEvent {owner; repo; base_ref; head_sha; _})
@@ -288,7 +288,7 @@ let callback _conn req body =
                     branch on GitLab."
                    owner repo )
               ()
-        | "math-comp", ("docker-mathcomp" | "math-comp") | "coq", "opam" ->
+        | "math-comp", ("docker-mathcomp" | "math-comp") | "rocq-prover", "opam" ->
             (fun () ->
               init_git_bare_repository ~bot_info
               >>= fun () ->
@@ -342,9 +342,9 @@ let callback _conn req body =
                  issue.owner issue.repo issue.number )
             ()
       | Ok
-          ( Some (1062161 as install_id) (* Coq's installation number *)
+          ( Some (1062161 as install_id) (* Rocq's installation number *)
           , PullRequestCardEdited
-              { project_number= 11 (* Coq's backporting project number *)
+              { project_number= 11 (* Rocq's backporting project number *)
               ; pr_id
               ; field
               ; old_value= "Request inclusion"
@@ -446,8 +446,8 @@ let callback _conn req body =
                         @@ Str.quote github_bot_name )
                       body
                     && comment_info.issue.pull_request
-                    && String.equal comment_info.issue.issue.owner "coq"
-                    && String.equal comment_info.issue.issue.repo "coq"
+                    && String.equal comment_info.issue.issue.owner "rocq-prover"
+                    && String.equal comment_info.issue.issue.repo "rocq"
                     && Option.is_some install_id
                   then
                     let full_ci =
@@ -473,8 +473,8 @@ let callback _conn req body =
                         (f "@%s:? [Mm]erge now" @@ Str.quote github_bot_name)
                       body
                     && comment_info.issue.pull_request
-                    && String.equal comment_info.issue.issue.owner "coq"
-                    && String.equal comment_info.issue.issue.repo "coq"
+                    && String.equal comment_info.issue.issue.owner "rocq-prover"
+                    && String.equal comment_info.issue.issue.repo "rocq"
                     && Option.is_some install_id
                   then (
                     (fun () ->
@@ -491,8 +491,8 @@ let callback _conn req body =
                         (f "@%s:? [Bb]ench native" @@ Str.quote github_bot_name)
                       body
                     && comment_info.issue.pull_request
-                    && String.equal comment_info.issue.issue.owner "coq"
-                    && String.equal comment_info.issue.issue.repo "coq"
+                    && String.equal comment_info.issue.issue.owner "rocq-prover"
+                    && String.equal comment_info.issue.issue.repo "rocq"
                     && Option.is_some install_id
                   then (
                     (fun () ->
@@ -510,8 +510,8 @@ let callback _conn req body =
                       ~regexp:(f "@%s:? [Bb]ench" @@ Str.quote github_bot_name)
                       body
                     && comment_info.issue.pull_request
-                    && String.equal comment_info.issue.issue.owner "coq"
-                    && String.equal comment_info.issue.issue.repo "coq"
+                    && String.equal comment_info.issue.issue.owner "rocq-prover"
+                    && String.equal comment_info.issue.issue.repo "rocq"
                     && Option.is_some install_id
                   then (
                     (fun () ->
@@ -604,11 +604,11 @@ let callback _conn req body =
             let close_after = 30 in
             (fun () ->
               action_as_github_app ~bot_info ~key ~app_id ~owner
-                (coq_check_needs_rebase_pr ~owner ~repo ~warn_after ~close_after
+                (rocq_check_needs_rebase_pr ~owner ~repo ~warn_after ~close_after
                    ~throttle:6 )
               >>= fun () ->
               action_as_github_app ~bot_info ~key ~app_id ~owner
-                (coq_check_stale_pr ~owner ~repo ~after:close_after ~throttle:4)
+                (rocq_check_stale_pr ~owner ~repo ~after:close_after ~throttle:4)
               )
             |> Lwt.async ;
             Server.respond_string ~status:`OK


### PR DESCRIPTION
This is based on the assumption that:
- the GitHub organization is renamed from coq to rocq-prover
- the GitHub repo is renamed at the same time from coq to rocq
- the Inria GitLab repo is renamed at the same time from coq to rocq
- but the Inria GitLab organization is not renamed yet.

This is also postponing the renaming of the bot itself.